### PR TITLE
Fixes clamp bug

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -76,14 +76,16 @@ Restricts value to a given range and returns closed available value. If only min
 | Param | Type | Description |
 | --- | --- | --- |
 | ...a | <code>number</code> \| <code>Array.&lt;number&gt;</code> | one or more numbers or arrays of numbers |
-| min | <code>number</code> \| <code>Array.&lt;number&gt;</code> | (optional) The minimum value this function will return. |
-| max | <code>number</code> \| <code>Array.&lt;number&gt;</code> | (optional) The maximum value this function will return. |
+| min | <code>number</code> \| <code>Array.&lt;number&gt;</code> | The minimum value this function will return. |
+| max | <code>number</code> \| <code>Array.&lt;number&gt;</code> | The maximum value this function will return. |
 
 **Returns**: <code>number</code> \| <code>Array.&lt;number&gt;</code> - The closest value between `min` (inclusive) and `max` (inclusive). Returns an array with values greater than or equal to `min` and less than or equal to `max` (if provided) at each index.  
 **Throws**:
 
 - `'Array length mismatch'` if `a`, `min`, and/or `max` are arrays of different lengths
 - `Min must be less than max` if `max` is less than `min`
+- `'Missing minimum value. You may want to use the 'max' function instead'` if min is not provided
+- `'Missing maximum value. You may want to use the 'min' function instead'` if max is not provided
 
 **Example**  
 ```js

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -83,7 +83,7 @@ Restricts value to a given range and returns closed available value. If only min
 **Throws**:
 
 - `'Array length mismatch'` if `a`, `min`, and/or `max` are arrays of different lengths
-- `Min must be less than max` if `max` is less than `min`
+- `'Min must be less than max'` if `max` is less than `min`
 - `'Missing minimum value. You may want to use the 'max' function instead'` if min is not provided
 - `'Missing maximum value. You may want to use the 'min' function instead'` if max is not provided
 

--- a/src/functions/clamp.js
+++ b/src/functions/clamp.js
@@ -1,17 +1,19 @@
 const findClamp = (a, min, max) => {
   if (min > max) throw new Error('Min must be less than max');
-  if (max != null) return Math.min(Math.max(a, min), max);
-  return Math.max(a, min);
+  return Math.min(Math.max(a, min), max);
 };
 
 /**
  * Restricts value to a given range and returns closed available value. If only min is provided, values are restricted to only a lower bound.
  * @param {...(number|number[])} a one or more numbers or arrays of numbers
- * @param {(number|number[])} min (optional) The minimum value this function will return.
- * @param {(number|number[])} max (optional) The maximum value this function will return.
+ * @param {(number|number[])} min The minimum value this function will return.
+ * @param {(number|number[])} max The maximum value this function will return.
  * @return {(number|number[])} The closest value between `min` (inclusive) and `max` (inclusive). Returns an array with values greater than or equal to `min` and less than or equal to `max` (if provided) at each index.
  * @throws `'Array length mismatch'` if `a`, `min`, and/or `max` are arrays of different lengths
  * @throws `Min must be less than max` if `max` is less than `min`
+ * @throws `'Missing minimum value. You may want to use the 'max' function instead'` if min is not provided
+ * @throws `'Missing maximum value. You may want to use the 'min' function instead'` if max is not provided
+ *
  * @example
  * clamp(1, 2, 3) // returns 2
  * clamp([10, 20, 30, 40], 15, 25) // returns [15, 20, 25, 25]
@@ -21,9 +23,12 @@ const findClamp = (a, min, max) => {
  */
 
 export function clamp(a, min, max) {
-  if (min === null) return a;
+  if (max === null)
+    throw new Error("Missing maximum value. You may want to use the 'min' function instead");
+  if (min === null)
+    throw new Error("Missing minimum value. You may want to use the 'max' function instead");
 
-  if (max !== null && Array.isArray(max)) {
+  if (Array.isArray(max)) {
     if (Array.isArray(a) && Array.isArray(min)) {
       if (a.length !== max.length || a.length !== min.length)
         throw new Error('Array length mismatch');

--- a/src/functions/clamp.js
+++ b/src/functions/clamp.js
@@ -1,6 +1,6 @@
 const findClamp = (a, min, max) => {
   if (min > max) throw new Error('Min must be less than max');
-  if (max) return Math.min(Math.max(a, min), max);
+  if (max != null) return Math.min(Math.max(a, min), max);
   return Math.max(a, min);
 };
 
@@ -21,14 +21,15 @@ const findClamp = (a, min, max) => {
  */
 
 export function clamp(a, min, max) {
-  if (!min) return a;
+  if (min === null) return a;
 
-  if (max && Array.isArray(max)) {
+  if (max !== null && Array.isArray(max)) {
     if (Array.isArray(a) && Array.isArray(min)) {
       if (a.length !== max.length || a.length !== min.length)
         throw new Error('Array length mismatch');
       return max.map((max, i) => findClamp(a[i], min[i], max));
     }
+
     if (Array.isArray(a)) {
       if (a.length !== max.length) throw new Error('Array length mismatch');
       return max.map((max, i) => findClamp(a[i], min, max));

--- a/src/functions/clamp.js
+++ b/src/functions/clamp.js
@@ -10,7 +10,7 @@ const findClamp = (a, min, max) => {
  * @param {(number|number[])} max The maximum value this function will return.
  * @return {(number|number[])} The closest value between `min` (inclusive) and `max` (inclusive). Returns an array with values greater than or equal to `min` and less than or equal to `max` (if provided) at each index.
  * @throws `'Array length mismatch'` if `a`, `min`, and/or `max` are arrays of different lengths
- * @throws `Min must be less than max` if `max` is less than `min`
+ * @throws `'Min must be less than max'` if `max` is less than `min`
  * @throws `'Missing minimum value. You may want to use the 'max' function instead'` if min is not provided
  * @throws `'Missing maximum value. You may want to use the 'min' function instead'` if max is not provided
  *

--- a/test/functions/clamp.spec.js
+++ b/test/functions/clamp.spec.js
@@ -7,6 +7,9 @@ describe('Clamp', () => {
     expect(clamp(10, 5, 8)).to.be.equal(8);
     expect(clamp(1, 2, 3)).to.be.equal(2);
     expect(clamp(0.5, 0.2, 0.4)).to.be.equal(0.4);
+    expect(clamp(3.58, 0, 1)).to.be.equal(1);
+    expect(clamp(-0.48, 0, 1)).to.be.equal(0);
+    expect(clamp(1.38, -1, 0)).to.be.equal(0);
   });
 
   it('arrays & numbers', () => {

--- a/test/functions/clamp.spec.js
+++ b/test/functions/clamp.spec.js
@@ -3,7 +3,6 @@ import { clamp } from '../../src/functions/clamp.js';
 
 describe('Clamp', () => {
   it('numbers', () => {
-    expect(clamp(10, 20)).to.be.equal(20);
     expect(clamp(10, 5, 8)).to.be.equal(8);
     expect(clamp(1, 2, 3)).to.be.equal(2);
     expect(clamp(0.5, 0.2, 0.4)).to.be.equal(0.4);
@@ -13,21 +12,32 @@ describe('Clamp', () => {
   });
 
   it('arrays & numbers', () => {
-    expect(clamp([10, 20, 30, 40], 15)).to.be.eql([15, 20, 30, 40]);
     expect(clamp([10, 20, 30, 40], 15, 25)).to.be.eql([15, 20, 25, 25]);
-    expect(clamp(10, [15, 2, 4, 20])).to.be.eql([15, 10, 10, 20]);
     expect(clamp(10, [15, 2, 4, 20], 25)).to.be.eql([15, 10, 10, 20]);
+    expect(clamp(5, 10, [20, 30, 40, 50])).to.be.eql([10, 10, 10, 10]);
     expect(clamp(35, 10, [20, 30, 40, 50])).to.be.eql([20, 30, 35, 35]);
     expect(clamp([1, 9], 3, [4, 5])).to.be.eql([3, 5]);
   });
 
   it('arrays', () => {
     expect(clamp([6, 28, 32, 10], [11, 2, 5, 10], [20, 21, 22, 23])).to.be.eql([11, 21, 22, 10]);
-    expect(clamp([11, 28, 60, 10], [1, 48, 3, -17])).to.be.eql([11, 48, 60, 10]);
   });
 
   it('errors', () => {
     expect(() => clamp(1, 4, 3)).to.throw('Min must be less than max');
     expect(() => clamp([1, 2], [3], 3)).to.throw('Array length mismatch');
+    expect(() => clamp([1, 2], [3], 3)).to.throw('Array length mismatch');
+    expect(() => clamp(10, 20, null)).to.throw(
+      "Missing maximum value. You may want to use the 'min' function instead"
+    );
+    expect(() => clamp([10, 20, 30, 40], 15, null)).to.throw(
+      "Missing maximum value. You may want to use the 'min' function instead"
+    );
+    expect(() => clamp(10, null, 30)).to.throw(
+      "Missing minimum value. You may want to use the 'max' function instead"
+    );
+    expect(() => clamp([11, 28, 60, 10], null, [1, 48, 3, -17])).to.throw(
+      "Missing minimum value. You may want to use the 'max' function instead"
+    );
   });
 });


### PR DESCRIPTION
Clamp uses falsy checks for `min` and `max` which causes problems when you pass in `0` for either parameter. This changes them to checks for null equality instead and adds a few unit tests.