### PR TITLE
chore: add travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: node_js
+
+node_js:
+  - "stable"
+  - "8"
+  - "10"
+
+cache:
+  directories:
+    - node_modules
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+    - /^v[0-9].*$/
+
+script:
+  - npm run lint
+  - npm run test


### PR DESCRIPTION
CI is always handy to have, and this will allow us to avoid git hooks.