### PR TITLE
Fix: handle properties with dots

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-filesize": "^1.5.0",
     "rollup-plugin-node-resolve": "^3.2.0",
-    "rollup-plugin-progress": "^0.4.0",
-    "yargs": "^10.0.3"
+    "rollup-plugin-progress": "^0.4.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,9 @@ export function interpret(node, scope, injectedFunctions) {
 }
 
 function getValue(scope, node) {
-  // attempt to read value, or reach into an object if value is undefined
-  const val = scope[node];
-  return typeof val !== 'undefined' ? val : get(scope, node);
+  // attempt to read value from nested object first, check for exact match if value is undefined
+  const val = get(scope, node);
+  return typeof val !== 'undefined' ? val : scope[node];
 }
 
 function getType(x) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,14 +29,16 @@ export function interpret(node, scope, injectedFunctions) {
 
   function exec(node) {
     const type = getType(node);
-    if (type === 'function') {
-      return invoke(node);
-    }
+
+    if (type === 'function') return invoke(node);
+
     if (type === 'string') {
-      const val = get(scope, node);
+      // attempt to read value, or reach into an object if value is undefined
+      const val = scope[node] || get(scope, node);
       if (typeof val === 'undefined') throw new Error(`Unknown variable: ${node}`);
       return val;
     }
+
     return node; // Can only be a number at this point
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,7 @@ export function interpret(node, scope, injectedFunctions) {
     if (type === 'function') return invoke(node);
 
     if (type === 'string') {
-      // attempt to read value, or reach into an object if value is undefined
-      const val = scope[node] || get(scope, node);
+      const val = getValue(scope, node);
       if (typeof val === 'undefined') throw new Error(`Unknown variable: ${node}`);
       return val;
     }
@@ -50,6 +49,12 @@ export function interpret(node, scope, injectedFunctions) {
     if (fn.skipNumberValidation || isOperable(execOutput)) return fn(...execOutput);
     return NaN;
   }
+}
+
+function getValue(scope, node) {
+  // attempt to read value, or reach into an object if value is undefined
+  const val = scope[node];
+  return typeof val !== 'undefined' ? val : get(scope, node);
 }
 
 function getType(x) {

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -160,6 +160,7 @@ describe('Evaluate', () => {
     expect(evaluate('foo.bar[0].baz', { foo: { bar: [{ baz: 30 }, { beer: 40 }] } })).to.be.equal(
       30
     );
+    expect(evaluate('"is.false"', { is: { null: null, false: false } })).to.be.equal(false);
   });
 
   it('equations', () => {

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -141,6 +141,19 @@ describe('Evaluate', () => {
     expect(evaluate('bar', { bar: [1, 2] })).to.be.eql([1, 2]);
   });
 
+  it('variables with spaces', () => {
+    expect(evaluate('"foo bar"', { 'foo bar': 10 })).to.be.equal(10);
+    expect(
+      evaluate('"key with many spaces in it"', { 'key with many spaces in it': 10 })
+    ).to.be.equal(10);
+  });
+
+  it('valiables with dots', () => {
+    expect(evaluate('foo.bar', { 'foo.bar': 20 })).to.be.equal(20);
+    expect(evaluate('"red.green"', { 'red.green': 30 })).to.be.equal(30);
+    expect(evaluate('"with space.val"', { 'with space.val': 42 })).to.be.equal(42);
+  });
+
   it('variables with dot notation', () => {
     expect(evaluate('foo.bar', { foo: { bar: 20 } })).to.be.equal(20);
     expect(evaluate('foo.bar[0].baz', { foo: { bar: [{ baz: 30 }, { beer: 40 }] } })).to.be.equal(

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -150,7 +150,8 @@ describe('Evaluate', () => {
 
   it('valiables with dots', () => {
     expect(evaluate('foo.bar', { 'foo.bar': 20 })).to.be.equal(20);
-    expect(evaluate('"red.green"', { 'red.green': 30 })).to.be.equal(30);
+    expect(evaluate('"is.null"', { 'is.null': null })).to.be.equal(null);
+    expect(evaluate('"is.false"', { 'is.null': null, 'is.false': false })).to.be.equal(false);
     expect(evaluate('"with space.val"', { 'with space.val': 42 })).to.be.equal(42);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,7 +2399,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0, find-up@^2.1.0:
+find-up@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
@@ -5063,35 +5063,10 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yargs:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.0.3.tgz#6542debd9080ad517ec5048fb454efe9e4d4aaae"
-  integrity sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==
-  dependencies:
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^8.0.0"
-
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs-parser@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.0.0.tgz#21d476330e5a82279a4b881345bf066102e219c6"
-  integrity sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=
   dependencies:
     camelcase "^4.1.0"
 


### PR DESCRIPTION
- Adds tests for selecting keys with dots in their name 
  - ex. `evaluate('foo.bar', { 'foo.bar': 20 })`
  - Also spaces *and* dots: `evaluate('"with space.val"', { 'with space.val': 42 })`
- Adds fix for selecting values with dots

### Example usage in Canvas

![screenshot 2018-12-03 15 38 30](https://user-images.githubusercontent.com/404731/49406148-f7e0a700-f711-11e8-91c7-cbb18c85fb62.png)
